### PR TITLE
chore(deps): bump go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###
 ### Builder Stage
 ###
-FROM docker.io/golang:latest AS builder
+FROM docker.io/golang:1.26.3 AS builder
 
 COPY . .
 RUN CGO_ENABLED=0 go install -ldflags="-s -w" ./cmd/openevt

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/brandon1024/OpenEVT
 
 go 1.24.0
 
-toolchain go1.26.1
+toolchain go1.26.3
 
 tool (
 	golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Upgrade Go to 1.26.3, which features some important security fixes.